### PR TITLE
fix rosbag record 

### DIFF
--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -89,6 +89,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
 
     if (vm.count("help")) {
       std::cout << desc << std::endl;
+      std::cout << ">> Starsky modified rosbag <<" << std::endl;
       exit(0);
     }
 

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -155,16 +155,16 @@ int Recorder::run() {
     last_buffer_warn_ = Time();
     queue_ = new std::queue<OutgoingMessage>;
 
+    if (!ros::Time::waitForValid(ros::WallDuration(2.0)))
+      ROS_WARN("/use_sim_time set to true and no clock published.  Still waiting for valid time...");
+
+    ros::Time::waitForValid();
+
     // Subscribe to each topic
     if (!options_.regex) {
     	foreach(string const& topic, options_.topics)
 			subscribe(topic);
     }
-
-    if (!ros::Time::waitForValid(ros::WallDuration(2.0)))
-      ROS_WARN("/use_sim_time set to true and no clock published.  Still waiting for valid time...");
-
-    ros::Time::waitForValid();
 
     start_time_ = ros::Time::now();
 

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -286,12 +286,11 @@ std::string Recorder::timeToStr(T ros_t)
 //! Callback to be invoked to save messages into a queue
 void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, string const& topic, shared_ptr<ros::Subscriber> subscriber, shared_ptr<int> count) {
     //void Recorder::doQueue(topic_tools::ShapeShifter::ConstPtr msg, string const& topic, shared_ptr<ros::Subscriber> subscriber, shared_ptr<int> count) {
-    Time rectime = Time::now();
     
     if (options_.verbose)
         cout << "Received message on topic " << subscriber->getTopic() << endl;
 
-    OutgoingMessage out(topic, msg_event.getMessage(), msg_event.getConnectionHeaderPtr(), rectime);
+    OutgoingMessage out(topic, msg_event.getMessage(), msg_event.getConnectionHeaderPtr(), msg_event.getReceiptTime());
     
     {
         boost::mutex::scoped_lock lock(queue_mutex_);

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -217,7 +217,7 @@ shared_ptr<ros::Subscriber> Recorder::subscribe(string const& topic) {
 
     ros::SubscribeOptions ops;
     ops.topic = topic;
-    ops.queue_size = 100;
+    ops.queue_size = 1000;
     ops.md5sum = ros::message_traits::md5sum<topic_tools::ShapeShifter>();
     ops.datatype = ros::message_traits::datatype<topic_tools::ShapeShifter>();
     ops.helper = boost::make_shared<ros::SubscriptionCallbackHelperT<


### PR DESCRIPTION
Use the timestamp from the message event, instead of ros::time::now --
this should help fix the problem of getting late timestamps in theory

**ros subscribers:**
In the background, ros creates a thread (or multiple threads?) that accept tcp connections, recieve messages, and store into an internal buffer / queue, one queue per topic
(length of queue set by the queue_size(number of messages) & buffer_size(number of bytes) options on ros subscriber constructor).

Then, the recieved messages are dispatched to subscriber callbacks. this either happens single threaded (if you call spin or spinOnce), or multithreaded (if you use asyncspinner).

**rosbag record:** (which is just a ros node, nothing magic about it)
In rosbag record, it's using asyncspinner w/ 10 threads, and it subscribes to many topics, all to the same callback doQueue, which when called, checks the current time, and adds the message + timestamp onto a queue. 

There's a separate thread in rosbag record that handles reading from that queue and writing the messages sequentially to disk. 

There's a lock that synchronizes between the threads, so that no two threads are writing to the queue at the same time & corrupting it. However this means while writing messages out to disk, new messages can't be added on to the queue, so those threads will pause at the line of code that acquires the lock. Since this is AFTER capturing the timestamp, you'd think this would be ok...but the problem is we only have 10 threads handling callbacks, so if writing messages out to disk takes longer than the time for 10 messages to come in, the messages will be stuck on the internal ros queue BEFORE calling our callback, meaning the ros::Time::now call wont be called until later, getting a later timestamp. We don't actually care about the time the message was moved from the internal ros queue onto the rosbag record queue, what we care about is when the message was actually published. We can't get that directly, so the next best thing is when the message was actually recieved. 